### PR TITLE
DAC ramp demo: Change buffer length calculation

### DIFF
--- a/ZmodDAC1411_Demo_Baremetal/src/main.cpp
+++ b/ZmodDAC1411_Demo_Baremetal/src/main.cpp
@@ -39,7 +39,7 @@ void dacRampDemo(float offset, float amplitude, float step, uint8_t channel, uin
 	float val;
 	uint32_t valBuf;
 	int16_t valRaw;
-	size_t length = (int)(amplitude/step) << 2;
+	size_t length = (int)((amplitude * 2.0) / step) * 2;
 	int i;
 	if (length > ((1<<14) - 1))
 	{

--- a/ZmodDAC1411_Demo_Linux/src/main.cpp
+++ b/ZmodDAC1411_Demo_Linux/src/main.cpp
@@ -41,7 +41,7 @@ void dacRampDemo(float offset, float amplitude, float step, uint8_t channel, uin
 	float val;
 	uint32_t valBuf;
 	int16_t valRaw;
-	size_t length = (int)(amplitude/step) << 2;
+	size_t length = (int)((amplitude * 2.0) / step) * 2;
 	int i;
 	if (length > ((1<<14) - 1))
 	{


### PR DESCRIPTION
Splits the shift left by two into two multiplies on either side of the float-to-int conversion. This means the length of one ramp for-loop is calculated then multiplied by two, correcting for a possible rounding error.

This solves a bug where some values of amplitude and step could cause buffer overflows, and was found through user code with amplitude 5 and step 2 (calculating a buffer length of 8 instead of 10), here: https://forum.digilentinc.com/topic/22675-zmod-adc-and-dac-initialization/

The overflow led to some pointer being overwritten prior to being freed, which caused the heap to underflow, and all further malloc calls to fail.